### PR TITLE
Memoize organization accounts

### DIFF
--- a/lib/aptible/auth/organization.rb
+++ b/lib/aptible/auth/organization.rb
@@ -61,10 +61,11 @@ module Aptible
       end
 
       def accounts
+        return @accounts if @accounts
         require 'aptible/api'
 
         accounts = Aptible::Api::Account.all(token: token, headers: headers)
-        accounts.select do |account|
+        @accounts = accounts.select do |account|
           (link = account.links[:organization]) && link.href == href
         end
       end

--- a/lib/aptible/auth/version.rb
+++ b/lib/aptible/auth/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Auth
-    VERSION = '0.8.3'
+    VERSION = '0.8.4'
   end
 end


### PR DESCRIPTION
This prevents multiple unnecessary api calls to /accounts by memoizing organization.accounts
