### PR TITLE
Rename SSHKey class so that client doesn't need to register an acronym

### DIFF
--- a/lib/aptible/auth/ssh_key.rb
+++ b/lib/aptible/auth/ssh_key.rb
@@ -1,6 +1,6 @@
 module Aptible
   module Auth
-    class SSHKey < Resource
+    class SshKey < Resource
       belongs_to :user
 
       field :id


### PR DESCRIPTION
The aptible-resource library's Aptible::Resource::Adapter class returns a type name from an object by (in most cases) grabbing the `_type` or `type` field from a hash and camelizing it. In the case of a user's ssh_keys, this type comes back from auth.aptible.com as "ssh_key". `"ssh_key".camelize` then returns "SshKey".

The dashboard-rails app registers an inflector acronym for "SSH" in config/initializers/inflections so that `"ssh_key".camelize` will return "SSHKey" in dashboard-rails, which is why naming the class SSHKey here works in that app, but this approach forces any of the clients of aptible-auth-ruby to register a similar acronym to access/modify a user's ssh keys. This patch renames the class so that it can be used without registering an acronym.

This patch will break dashboard-rails if it were to upgrade. Should I fix dashboard-rails for the upgrade? Should I instead register an "SSH" inflector acronym in aptible-auth-ruby and leave the class named as-is? It seems strange to register acronyms in this library, since they'd also bleed through to any app that uses the library.

/cc @sandersonet @fancyremarker 