### PR TITLE
Bump aptible-resource version to 0.3.1.

### DIFF
--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aptible-billing'
-  spec.add_dependency 'aptible-resource', '>= 0.2.1'
+  spec.add_dependency 'aptible-resource', '>= 0.3.1'
   spec.add_dependency 'stripe', '>= 1.13.0'
   spec.add_dependency 'gem_config'
   spec.add_dependency 'oauth2-aptible'

--- a/lib/aptible/auth/version.rb
+++ b/lib/aptible/auth/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Auth
-    VERSION = '0.10.0'
+    VERSION = '0.11.0'
   end
 end


### PR DESCRIPTION
This version has removed the usage of the type metafield.

cc @fancyremarker 