### PR TITLE
Add can manage compliance back to organization

### DIFF
--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.0'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'pry'
 end

--- a/lib/aptible/auth/organization.rb
+++ b/lib/aptible/auth/organization.rb
@@ -30,6 +30,11 @@ module Aptible
         )
       end
 
+      def can_manage_compliance?
+        return false unless billing_detail
+        %w(production pilot).include?(billing_detail.plan)
+      end
+
       def privileged_roles
         roles.select(&:privileged?)
       end

--- a/lib/aptible/auth/version.rb
+++ b/lib/aptible/auth/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Auth
-    VERSION = '0.11.0'
+    VERSION = '0.11.1'
   end
 end

--- a/spec/aptible/auth/organization_spec.rb
+++ b/spec/aptible/auth/organization_spec.rb
@@ -1,6 +1,36 @@
 require 'spec_helper'
 
 describe Aptible::Auth::Organization do
+  describe '#can_manage_compliance?' do
+    before { subject.stub(:billing_detail)  { billing_detail } }
+
+    context 'without a billing detail' do
+      let(:billing_detail) { nil }
+      it 'should return false' do
+        expect(subject.can_manage_compliance?).to eq false
+      end
+    end
+
+    context 'with a billing detail' do
+      let(:billing_detail) { double Aptible::Billing::BillingDetail }
+
+      it 'should return true with production plan' do
+        billing_detail.stub(:plan) { 'production' }
+        expect(subject.can_manage_compliance?).to eq true
+      end
+
+      it 'should return false with development plan' do
+        billing_detail.stub(:plan) { 'development' }
+        expect(subject.can_manage_compliance?).to eq false
+      end
+
+      it 'should return false with platform plan' do
+        billing_detail.stub(:plan) { 'platform' }
+        expect(subject.can_manage_compliance?).to eq false
+      end
+    end
+  end
+
   describe '#security_officer' do
     let(:user) { double 'Aptible::Auth::User' }
 


### PR DESCRIPTION
This was removed in https://github.com/aptible/aptible-auth-ruby/commit/9032a6b5689979e72f57ea6745161096e17a31ec but is still referenced throughout compliance and gridiron.  