### PR TITLE
Do not delete options from borrowed Hash

### DIFF
--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -49,6 +49,7 @@ module Aptible
       end
 
       def process_options(options)
+        options = options.dup
         if (email = options.delete(:email)) &&
            (password = options.delete(:password))
           authenticate_user(email, password, options)

--- a/spec/aptible/auth/token_spec.rb
+++ b/spec/aptible/auth/token_spec.rb
@@ -27,6 +27,13 @@ describe Aptible::Auth::Token do
         subject: 'user@example.com'
       )
     end
+
+    it 'should not alter the hash it receives' do
+      options = { email: 'some email' }
+      options_before = options.dup
+      expect { described_class.create options }.to raise_error(/Unrecognized/)
+      expect(options).to eq(options_before)
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
I don't think it should be expected for a caller to see the hash they pass in changed when they create a token.

cc @fancyremarker 