### PR TITLE
Make Token behave as an actual HyperResource

### DIFF
--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -3,44 +3,63 @@ require 'oauth2'
 module Aptible
   module Auth
     class Token < Resource
-      attr_accessor :access_token, :refresh_token, :expires_at
+      # Unlike other resources, tokens aren't created in a REST fashion.
+      # Instead, they're created via OAuth grants. This means we need to
+      # override the way HyperResource / aptible-resource normally do things
+      # and plug in an OAuth library.
+      #
+      # To do so, we take control of the creation arguments and feed them into
+      # the OAuth2 library (in Token.create!), and then feed the response back
+      # to HyperResource (in Token#apply_oauth_response).
+      belongs_to :user
+      belongs_to :actor
 
-      def self.create(options)
+      field :access_token
+      field :refresh_token
+      field :expires_at
+
+      def self.create!(options)
         token = new
         token.process_options(options)
         token
+      rescue OAuth2::Error => e
+        # Rethrow OAuth2::Error as HyperResource::ResponseError for
+        # aptible-resource to handle
+        raise HyperResource::ResponseError.new(e.code, response: e.response,
+                                                       cause: e)
       end
 
       def authenticate_user(email, password, options = {})
         options[:scope] ||= 'manage'
-        response = oauth.password.get_token(email, password, options)
-        parse_oauth_response(response)
+        oauth_token = oauth.password.get_token(email, password, options)
+        apply_oauth_response(oauth_token)
       end
 
       def authenticate_client(id, secret, subject, options = {})
         options[:scope] ||= 'manage'
-        response = oauth.assertion.get_token({
+        oauth_token = oauth.assertion.get_token({
           iss: id,
           sub: subject
         }.merge(signing_params_from_secret(secret).merge(options)))
-        parse_oauth_response(response)
+        apply_oauth_response(oauth_token)
       end
 
       def authenticate_impersonate(subject_token, subject_token_type, options)
         # TODO: This duplicates aptible-resource, is it worth extracting?
-        token = case token = options.delete(:token)
-                when Aptible::Resource::Base then token.access_token
-                when Fridge::AccessToken then token.to_s
-                when String then token
-                else bearer_token
-                end
+        actor_token = \
+          case actor_token = options.delete(:token)
+          when Aptible::Resource::Base then actor_token.access_token
+          when Fridge::AccessToken then actor_token.to_s
+          when String then actor_token
+          else bearer_token
+          end
 
         # TODO: Do we want to check whether the token is non-nil at this stage?
         options[:scope] ||= 'manage'
-        response = oauth.token_exchange.get_token(
-          token, 'urn:ietf:params:oauth:token-type:jwt',
+        oauth_token = oauth.token_exchange.get_token(
+          actor_token, 'urn:ietf:params:oauth:token-type:jwt',
           subject_token, subject_token_type, options)
-        parse_oauth_response(response)
+        apply_oauth_response(oauth_token)
       end
 
       def oauth
@@ -68,12 +87,34 @@ module Aptible
         end
       end
 
+      def token
+        # If the user set an arbitrary token, then we'll return that one,
+        # otherwise we'll fall back to the Token itself, which makes it
+        # possible to create a token and immediately access it #user or #actor
+        # methods.
+        # NOTE: Setting the token after the fact probably doesn't work anyway,
+        # since the Authorization header won't be updated.
+        @token || access_token
+      end
+
+      def expires_at
+        # The Auth API returns the expiry as a timestamp (i.e. an Integer), but
+        # our API client knows only to handle times as strings. This overrides
+        # the field method for expires_at to return a Time despite the
+        # underlying API field being an Integer.
+        Time.at(attributes[:expires_at])
+      end
+
       private
 
-      def parse_oauth_response(response)
-        @access_token = response.token
-        @refresh_token = response.refresh_token
-        @expires_at = Time.at(response.expires_at)
+      def apply_oauth_response(oauth_token)
+        # apply() + loaded is what HyperResource normally does after
+        # deserializing a response back from the API. On top of that, we need
+        # to set the Authorization header so that the token can be used to make
+        # further API requests (e.g. accessing token#user or token#actor).
+        adapter.apply(oauth_token.to_hash, self)
+        self.loaded = true
+        headers['Authorization'] = "Bearer #{bearer_token}"
         self
       end
 


### PR DESCRIPTION
Currently, Tokens are a subclass of Aptible::Auth::Resource, but
they don't behave like one at all:

- Only a subset of their attributes can be used: specifically,
  `access_token`, `refresh_token`, and `expires_at`. This means other
  fields — like `actor` or `user` — are unavailable.
- None of the HyperResource methods work. For example, if you try to
  `get` a token, then a request will be made to `APTIBLE_AUTH_ROOT_URL`,
  not to the HREF of the token itself. Generally speaking, the token
  can't be used to make any follow on requests because it doesn't set
  the `Authorization` header.
- `Token.create` throws exceptions (instead of setting `.errors`), and
  `Token.create!` doesn't work at all (it doesn't go through the OAuth2
  mechanism).

To avoid breaking expectations any longer, this patch fixes those issues
and makes Tokens behave like an actual resource. However, we might need
to update clients to use `Token.create!` if they expect `Token.create`
to throw an exception.

---

Note: this is needed to make https://github.com/aptible/api.aptible.com/pull/347 work. 

cc @fancyremarker 