### PR TITLE
Throw in Token.create

### DIFF
--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -18,10 +18,17 @@ module Aptible
       field :refresh_token
       field :expires_at
 
-      def self.create!(options)
+      def self.create(options)
+        # For backwards compatibility: we used to throw in .create (which isn't
+        # consistent with other resources), and we probably need to continue
+        # doing this. We also need to continue throwing a OAuth2::Error.
         token = new
         token.process_options(options)
         token
+      end
+
+      def self.create!(options)
+        Token.create(options)
       rescue OAuth2::Error => e
         # Rethrow OAuth2::Error as HyperResource::ResponseError for
         # aptible-resource to handle


### PR DESCRIPTION
As of https://github.com/aptible/aptible-auth-ruby/pull/49, Token
behaves like other HyperResource, and doesn't throw on .create (which is
probably not ideal, but is consistent).

Unfortunately, some clients relie on create throwing (namely:
`aptible-cli`), and those clients don't pin a specific version, so we
have no choice but to preserve backwards compatibility here.

Those clients also rely on the error being a OAuth2 error, so there's
that too.

--

cc @fancyremarker. FYI, I yanked 0.11.4 to avoid having customers install this aptible-auth-ruby 