### PR TITLE
Token: expose create_at, updated_at as Time fields

### DIFF
--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -18,6 +18,9 @@ module Aptible
       field :refresh_token
       field :expires_at
 
+      field :created_at, type: Time
+      field :updated_at, type: Time
+
       def self.create(options)
         # For backwards compatibility: we used to throw in .create (which isn't
         # consistent with other resources), and we probably need to continue


### PR DESCRIPTION
This will be useful for the CLI to be able to express the duration
`expires_at - created_at`.

cc @fancyremarker 