### PR TITLE
Add Role#type, deprecate Role#privileged? and related legacy methods

### DIFF
--- a/lib/aptible/auth/role.rb
+++ b/lib/aptible/auth/role.rb
@@ -7,7 +7,7 @@ module Aptible
 
       field :id
       field :name
-      field :privileged, type: Aptible::Resource::Boolean
+      field :type
       field :created_at, type: Time
       field :updated_at, type: Time
 

--- a/lib/aptible/auth/user.rb
+++ b/lib/aptible/auth/user.rb
@@ -12,72 +12,13 @@ module Aptible
       field :created_at, type: Time
       field :updated_at, type: Time
 
-      # rubocop:disable MethodLength
-      def set_organization_roles(organization, roles)
-        self.roles.each do |role|
-          next unless role.organization.id == organization.id
-          next if roles.map(&:id).include? role.id
-
-          role_membership = role.memberships.find do |membership|
-            membership.user.id == id
-          end
-
-          role_membership.destroy
-        end
-
-        add_to_roles(roles)
-      end
-      # rubocop:enable MethodLength
-
       def organizations
         roles.map(&:organization).uniq(&:id)
-      end
-
-      def organization_roles(organization)
-        roles.select do |role|
-          role.links['organization'].href == organization.href
-        end
-      end
-
-      def organization_privileged_roles(organization)
-        privileged_roles.select do |role|
-          role.links['organization'].href == organization.href
-        end
       end
 
       def operations
         # TODO: Implement query params for /operations
         []
-      end
-
-      def privileged_organizations
-        privileged_roles.map(&:organization)
-      end
-
-      def privileged_roles
-        @privileged_roles ||= roles.select(&:privileged?)
-      end
-
-      # rubocop:disable PredicateName
-      def is_billing_contact?(organization)
-        organization.billing_contact_id && organization.billing_contact_id == id
-      end
-
-      def has_role?(role)
-        roles.select { |user_role| role.id == user_role.id }.count > 0
-      end
-      # rubocop:enable PredicateName
-
-      def can_manage?(organization)
-        privileged_organizations.map(&:id).include? organization.id
-      end
-
-      def add_to_roles(roles)
-        roles.each { |role| add_to_role(role) }
-      end
-
-      def add_to_role(role)
-        role.create_membership(user: self, token: token) unless has_role? role
       end
     end
   end

--- a/spec/aptible/auth/user_spec.rb
+++ b/spec/aptible/auth/user_spec.rb
@@ -1,35 +1,6 @@
 require 'spec_helper'
 
 describe Aptible::Auth::User do
-  describe '#can_manage?' do
-    let(:developer) { double 'Aptible::Auth::Role' }
-    let(:owner) { double 'Aptible::Auth::Role' }
-    let(:org) { double 'Aptible::Auth::Organization' }
-
-    before do
-      org.stub(:id) { 1 }
-      developer.stub(:organization) { org }
-      allow(developer).to receive(:privileged?).and_return(false)
-      owner.stub(:organization) { org }
-      allow(owner).to receive(:privileged?).and_return(true)
-    end
-
-    it 'should return false if not member of org privileged role' do
-      subject.stub(:roles) { [developer] }
-      expect(subject.can_manage?(org)).to eq false
-    end
-
-    it 'should return true if member of org privileged role' do
-      subject.stub(:roles) { [developer, owner] }
-      expect(subject.can_manage?(org)).to eq true
-    end
-
-    it 'should return false if member of no roles' do
-      subject.stub(:roles) { [] }
-      expect(subject.can_manage?(org)).to eq false
-    end
-  end
-
   describe '#organizations' do
     let(:so) { double 'Aptible::Auth::Role' }
     let(:owner) { double 'Aptible::Auth::Role' }
@@ -49,91 +20,6 @@ describe Aptible::Auth::User do
     it 'should return unique organizations only' do
       subject.stub(:roles) { [so, owner] }
       expect(subject.organizations.count).to eq 1
-    end
-  end
-
-  describe '#roles' do
-    let(:so) { double 'Aptible::Auth::Role' }
-    let(:owner) { double 'Aptible::Auth::Role' }
-
-    before do
-      so.stub(:id) { 1 }
-      owner.stub(:id) { 2 }
-    end
-
-    it 'should have role' do
-      subject.stub(:roles) { [so] }
-      expect(subject.has_role?(so)).to eq true
-      expect(subject.has_role?(owner)).to eq false
-    end
-  end
-
-  describe '#set_organization_roles' do
-    let(:so) { double 'Aptible::Auth::Role' }
-    let(:owner) { double 'Aptible::Auth::Role' }
-    let(:org) { double 'Aptible::Auth::Organization' }
-    let(:owner_membership) { double 'Aptible::Auth::Membership' }
-    let(:so_membership) { double 'Aptible::Auth::Membership' }
-
-    before do
-      org.stub(:id) { 1 }
-
-      so.stub(:organization) { org }
-      so.stub(:id) { 1 }
-
-      owner.stub(:organization) { org }
-      owner.stub(:id) { 2 }
-
-      allow(Aptible::Auth::Role).to receive(:find)
-        .with(1, token: 'token').and_return(so)
-      allow(Aptible::Auth::Role).to receive(:find)
-        .with(2, token: 'token').and_return(owner)
-    end
-
-    it 'should overwrite existing memberships' do
-      subject.stub(:roles) { [so] }
-      subject.stub(:token) { 'token' }
-      subject.stub(:headers) { {} }
-      so_membership.stub(:user) { subject }
-      so_membership.stub(:role) { so }
-      so.stub(:memberships) { [so_membership] }
-      owner.stub(:memberships) { [] }
-
-      expect(so_membership).to receive(:destroy)
-      expect(owner).to receive(:create_membership)
-        .with(user: subject, token: 'token')
-
-      subject.set_organization_roles(org, [owner])
-    end
-
-    it 'should create new memberships' do
-      subject.stub(:roles) { [] }
-      subject.stub(:token) { 'token' }
-      subject.stub(:headers) { {} }
-      so.stub(:memberships) { [] }
-      owner.stub(:memberships) { [] }
-
-      expect(so).to receive(:create_membership)
-        .with(user: subject, token: 'token')
-      expect(owner).to receive(:create_membership)
-        .with(user: subject, token: 'token')
-
-      subject.set_organization_roles(org, [so, owner])
-    end
-
-    it 'should delete all existing memberships' do
-      subject.stub(:roles) { [so, owner] }
-      so.stub(:memberships) { [so_membership] }
-      owner.stub(:memberships) { [owner_membership] }
-      so_membership.stub(:user) { subject }
-      so_membership.stub(:role) { so }
-      owner_membership.stub(:user) { subject }
-      owner_membership.stub(:role) { owner }
-
-      expect(so_membership).to receive(:destroy)
-      expect(owner_membership).to receive(:destroy)
-
-      subject.set_organization_roles(org, [])
     end
   end
 end


### PR DESCRIPTION
See aptible/auth.aptible.com#219

The removed methods were used primarily in [dashboard-rails](https://github.com/aptible/dashboard-rails)