### PR TITLE
Assertion: translate :expires_in to :exp

### DIFF
--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'timecop', '~> 0.8.1'
 end

--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -47,6 +47,11 @@ module Aptible
 
       def authenticate_client(id, secret, subject, options = {})
         options[:scope] ||= 'manage'
+        # Unlike other methods, the assertion token grant requirs an "exp"
+        # parameter rather than expires_in, but since we'd like to expose a
+        # consistent API to consumers, we override it here
+        expires_in = options.delete(:expires_in)
+        options[:exp] = Time.now.utc.to_i + expires_in if expires_in
         oauth_token = oauth.assertion.get_token({
           iss: id,
           sub: subject

--- a/spec/aptible/auth/token_spec.rb
+++ b/spec/aptible/auth/token_spec.rb
@@ -112,6 +112,20 @@ describe Aptible::Auth::Token do
       subject.authenticate_client(*args)
     end
 
+    it 'should replace expires_in in exp' do
+      args << { expires_in: 1800 }
+      Timecop.freeze do
+        expect(oauth.assertion).to receive(:get_token).with(
+          iss: 'id',
+          sub: 'user@example.com',
+          exp: Time.now.to_i + 1800,
+          algorithm: 'foobar',
+          scope: 'manage'
+        )
+        subject.authenticate_client(*args)
+      end
+    end
+
     it 'should set the access_token' do
       subject.authenticate_client(*args)
       expect(subject.access_token).to eq 'access_token'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
+Bundler.require :development
+
 # Load shared spec files
 Dir["#{File.dirname(__FILE__)}/shared/**/*.rb"].each do |file|
   require file


### PR DESCRIPTION
This is a supporting change for https://github.com/aptible/auth.aptible.com/pull/241, to allow clients to pass `:expires_in` when creating a token and have that translated to `:exp` if they're doing an assertion (which makes the parameters consistent across methods).

cc @fancyremarker @blakepettersson 