### PR TITLE
Remove activesupport pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.0'
+
 # Specify your gem's dependencies in aptible-auth.gemspec
 gemspec

--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aptible-billing'
-  spec.add_dependency 'activesupport', '~> 4.0'
   spec.add_dependency 'aptible-resource', '>= 0.3.1'
   spec.add_dependency 'stripe', '>= 1.13.0'
   spec.add_dependency 'gem_config'


### PR DESCRIPTION
We only need this when installing dependencies in test (so it can go in
the Gemfile), whereas having it in the gemspec prevents users of this
gem from upgrading to Rails 5.

cc @fancyremarker @blakepettersson 