### PR TITLE
Speedier user organizations

### DIFF
--- a/lib/aptible/auth/membership.rb
+++ b/lib/aptible/auth/membership.rb
@@ -2,7 +2,7 @@ module Aptible
   module Auth
     class Membership < Resource
       belongs_to :role
-      belongs_to :user
+      embeds_one :user
 
       field :id
       field :created_at, type: Time

--- a/lib/aptible/auth/user.rb
+++ b/lib/aptible/auth/user.rb
@@ -14,7 +14,9 @@ module Aptible
       field :updated_at, type: Time
 
       def organizations
-        roles.map(&:organization).uniq(&:id)
+        # Establish uniqueness of requests before loading all organizations
+        # We can do this by reading the `organization` link for each role
+        roles.map(&:links).map(&:organization).uniq(&:base_href).map(&:get)
       end
 
       def operations

--- a/lib/aptible/auth/user.rb
+++ b/lib/aptible/auth/user.rb
@@ -16,7 +16,7 @@ module Aptible
       def organizations
         # Establish uniqueness of requests before loading all organizations
         # We can do this by reading the `organization` link for each role
-        roles.map(&:links).map(&:organization).uniq(&:base_href).map(&:get)
+        roles.map(&:links).map(&:organization).uniq(&:href).map(&:get)
       end
 
       def operations

--- a/spec/aptible/auth/user_spec.rb
+++ b/spec/aptible/auth/user_spec.rb
@@ -7,7 +7,7 @@ describe Aptible::Auth::User do
     let(:owner) { double 'Aptible::Auth::Role' }
     let(:org) { double 'Aptible::Auth::Organization' }
     let(:organization_link) do
-      double('Aptible::Auth::Organization::Link', base_href: '/organizations/1')
+      double('Aptible::Auth::Organization::Link', href: '/organizations/1')
     end
     let(:role_link) { double('Aptible::Auth::Role::Link') }
 

--- a/spec/aptible/auth/user_spec.rb
+++ b/spec/aptible/auth/user_spec.rb
@@ -2,14 +2,22 @@ require 'spec_helper'
 
 describe Aptible::Auth::User do
   describe '#organizations' do
+    let(:org_id) { 1 }
     let(:so) { double 'Aptible::Auth::Role' }
     let(:owner) { double 'Aptible::Auth::Role' }
     let(:org) { double 'Aptible::Auth::Organization' }
+    let(:organization_link) do
+      double('Aptible::Auth::Organization::Link', base_href: '/organizations/1')
+    end
+    let(:role_link) { double('Aptible::Auth::Role::Link') }
 
     before do
-      org.stub(:id) { 1 }
-      so.stub(:organization) { org }
-      owner.stub(:organization) { org }
+      role_link.stub(:organization) { organization_link }
+      organization_link.stub(:get) { org }
+
+      org.stub(:id) { org_id }
+      so.stub(:links) { role_link }
+      owner.stub(:links) { role_link }
     end
 
     it 'should return empty if no organizations' do


### PR DESCRIPTION
This PR makes two minor changes that net pretty significant speed improvements for Gridiron (and probably dashboard in general).

First, `User#organizations` was loading `role.organization` for every single role, even if the organization was already side loaded from another role.  This PR improves `User#organizations` to establish uniqueness before making any requests.  This removes an AUTH request for each of the user's roles--In the case of gridiron, that's a lot of roles for the initial user!

Secondly,  Auth has been embedding users in membership responses for a while.  Since `Role#users` just maps over memberships to return users, we can again remove several AUTH requests by just updating from `belongs_to` to `embeds_one` for `Membership#user`. 

---

cc @fancyremarker @krallin 

