### PR TITLE
Trim dependencies

### DIFF
--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 2.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'timecop', '~> 0.8.1'

--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'aptible-resource', '~> 1.0'
   spec.add_dependency 'gem_config'
   spec.add_dependency 'oauth2-aptible', '~> 0.10.0'

--- a/lib/aptible/auth/organization.rb
+++ b/lib/aptible/auth/organization.rb
@@ -1,5 +1,3 @@
-require 'aptible/billing'
-
 module Aptible
   module Auth
     class Organization < Resource
@@ -22,17 +20,6 @@ module Aptible
       field :security_alert_email
       field :ops_alert_email
       field :security_officer_id
-
-      def billing_detail
-        @billing_detail ||= Aptible::Billing::BillingDetail.find(
-          id, token: token, headers: headers
-        )
-      end
-
-      def can_manage_compliance?
-        return false unless billing_detail
-        %w(production pilot).include?(billing_detail.plan)
-      end
 
       def privileged_roles
         roles.select(&:privileged?)

--- a/spec/aptible/auth/organization_spec.rb
+++ b/spec/aptible/auth/organization_spec.rb
@@ -1,36 +1,6 @@
 require 'spec_helper'
 
 describe Aptible::Auth::Organization do
-  describe '#can_manage_compliance?' do
-    before { subject.stub(:billing_detail) { billing_detail } }
-
-    context 'without a billing detail' do
-      let(:billing_detail) { nil }
-      it 'should return false' do
-        expect(subject.can_manage_compliance?).to eq false
-      end
-    end
-
-    context 'with a billing detail' do
-      let(:billing_detail) { double Aptible::Billing::BillingDetail }
-
-      it 'should return true with production plan' do
-        billing_detail.stub(:plan) { 'production' }
-        expect(subject.can_manage_compliance?).to eq true
-      end
-
-      it 'should return false with development plan' do
-        billing_detail.stub(:plan) { 'development' }
-        expect(subject.can_manage_compliance?).to eq false
-      end
-
-      it 'should return false with platform plan' do
-        billing_detail.stub(:plan) { 'platform' }
-        expect(subject.can_manage_compliance?).to eq false
-      end
-    end
-  end
-
   describe '#security_officer' do
     let(:user) { double 'Aptible::Auth::User' }
 


### PR DESCRIPTION
We no longer need to access billing_detail from an Organization, so we
can drop aptible-billing as a dependency here (which, considering it
pulls in the stripe gem, actually drops quite a lot of dependencies).

--

cc @fancyremarker 