### PR TITLE
remove dependency on forked oauth2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'activesupport', '~> 4.0'
-gem 'rack', '~> 1.6'
-
 # Specify your gem's dependencies in aptible-auth.gemspec
 gemspec

--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.3', '< 3.0'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 11.0'
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'pry'

--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'aptible-resource', '~> 1.0'
   spec.add_dependency 'gem_config'
-  spec.add_dependency 'oauth2-aptible', '~> 0.10.0'
+  spec.add_dependency 'oauth2', '~> 1.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3', '< 3.0'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.0'

--- a/lib/aptible/auth.rb
+++ b/lib/aptible/auth.rb
@@ -18,3 +18,4 @@ end
 
 require 'aptible/auth/resource'
 require 'aptible/auth/agent'
+require 'aptible/auth/oauth2_config'

--- a/lib/aptible/auth/oauth2_config.rb
+++ b/lib/aptible/auth/oauth2_config.rb
@@ -1,5 +1,11 @@
 require 'oauth2'
 
-OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json']) do |body|
-  MultiJson.load(body) rescue body
+json_mime_types = [
+  'application/json',
+  'text/javascript',
+  'application/hal+json'
+]
+
+OAuth2::Response.register_parser(:json, json_mime_types) do |body|
+  MultiJson.load(body) rescue body # rubocop:disable RescueModifier
 end

--- a/lib/aptible/auth/oauth2_config.rb
+++ b/lib/aptible/auth/oauth2_config.rb
@@ -1,0 +1,5 @@
+require 'oauth2'
+
+OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json']) do |body|
+  MultiJson.load(body) rescue body
+end

--- a/lib/aptible/auth/version.rb
+++ b/lib/aptible/auth/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Auth
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.0.2'.freeze
   end
 end


### PR DESCRIPTION
This removes the dependency on Aptible's forked OAuth2 gem, since both of the issues mentioned in the README have been fixed. Additionally, it removes dependencies specified in the Gemfile, rather than the gemspec. I'm guessing that those were only intended for development purposes, which is why I did not move them to the gemspec. This has the side effect of also removing the dependency on activesupport 4 specifically, allowing the library to work with both versions 4 and 5.