### PR TITLE
target latest oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,2 @@
 source 'https://rubygems.org'
-
-gem 'activesupport', '~> 4.0'
-gem 'rack', '~> 1.6'
-
-# Specify your gem's dependencies in aptible-auth.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Add the following line to your application's Gemfile.
 
 And then run `bundle install`.
 
-A forked version of the OAuth2 gem is necessary until [intridea/oauth2#165](https://github.com/intridea/oauth2/pull/165) and [intridea/oauth2#166](https://github.com/intridea/oauth2/pull/166) are merged.
-
 ## Usage
 
 First, get a token:

--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -22,10 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aptible-resource', '~> 1.0'
   spec.add_dependency 'gem_config'
-  spec.add_dependency 'oauth2-aptible', '~> 0.10.0'
+  spec.add_dependency 'oauth2', '~> 1.4'
 
   spec.add_development_dependency 'aptible-tasks', '>= 0.6.0'
-  spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -1,4 +1,5 @@
 require 'oauth2'
+require 'oauth2/strategy/token_exchange'
 
 module Aptible
   module Auth

--- a/lib/oauth2/strategy/token_exchange.rb
+++ b/lib/oauth2/strategy/token_exchange.rb
@@ -1,0 +1,40 @@
+# rubocop:disable all
+module OAuth2
+  module Strategy
+    # The Token Exchange strategy
+    #
+    # @see https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-03#section-4.1
+    class TokenExchange < Base
+      GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'
+
+      # Not used for this strategy
+      #
+      # @raise [NotImplementedError]
+      def authorize_url
+        fail(NotImplementedError, 'The authorization endpoint is not used in this strategy')
+      end
+
+      # Retrieve an access token given the specified End User username and password.
+      #
+      # @param [String] username the End User username
+      # @param [String] password the End User password
+      # @param [Hash] params additional params
+      def get_token(actor_token, actor_token_type, subject_token, subject_token_type, params = {}, opts = {})
+        params = {'grant_type'          => GRANT_TYPE,
+                  'actor_token'         => actor_token,
+                  'actor_token_type'    => actor_token_type,
+                  'subject_token'       => subject_token,
+                  'subject_token_type'  => subject_token_type
+        }.merge(client_params).merge(params)
+        @client.get_token(params, opts)
+      end
+    end
+  end
+
+  # Add strategy to OAuth2::Client
+  class Client
+    def token_exchange
+      @token_exchange ||= OAuth2::Strategy::TokenExchange.new(self)
+    end
+  end
+end


### PR DESCRIPTION
Can I get a sanity check here?

I want to get to a current version of faraday and the dependency on an outdated fork of oauth2 was preventing this. Seems like both issues that required the fork are now solved in oauth2. (and we can monkey_patch in the token_exchange strategy)

This would also resolve all of the reported issues