### PR TITLE
fix client_params

### DIFF
--- a/lib/oauth2/strategy/token_exchange.rb
+++ b/lib/oauth2/strategy/token_exchange.rb
@@ -25,7 +25,7 @@ module OAuth2
                   'actor_token_type'    => actor_token_type,
                   'subject_token'       => subject_token,
                   'subject_token_type'  => subject_token_type
-        }.merge(client_params).merge(params)
+        }.merge(params)
         @client.get_token(params, opts)
       end
     end

--- a/spec/oauth2/lib/token_exchange_spec.rb
+++ b/spec/oauth2/lib/token_exchange_spec.rb
@@ -1,0 +1,58 @@
+# rubocop:disable all
+require 'oauth2'
+require 'oauth2/strategy/token_exchange'
+RSpec.describe OAuth2::Strategy::TokenExchange do
+  let(:client) do
+    cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
+    cli.connection.build do |b|
+      b.adapter :test do |stub|
+        stub.post('/oauth/token') do |env|
+          case @mode
+          when 'formencoded'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']
+          when 'json'
+            [200, {'Content-Type' => 'application/json'}, '{"expires_in":600,"access_token":"salmon","refresh_token":"trout"}']
+          end
+        end
+      end
+    end
+    cli
+  end
+  subject { client.token_exchange }
+
+  describe '#authorize_url' do
+    it 'raises NotImplementedError' do
+      expect { subject.authorize_url }.to raise_error(NotImplementedError)
+    end
+  end
+
+  %w(json formencoded).each do |mode|
+    describe "#get_token (#{mode})" do
+      before do
+        @mode = mode
+        @access = subject.get_token('actor token', 'actor token type', 'subject token', 'subject token type')
+      end
+
+      it 'returns AccessToken with same Client' do
+        expect(@access.client).to eq(client)
+      end
+
+      it 'returns AccessToken with #token' do
+        expect(@access.token).to eq('salmon')
+      end
+
+      it 'returns AccessToken with #refresh_token' do
+        expect(@access.refresh_token).to eq('trout')
+      end
+
+      it 'returns AccessToken with #expires_in' do
+        expect(@access.expires_in).to eq(600)
+      end
+
+      it 'returns AccessToken with #expires_at' do
+        expect(@access.expires_at).not_to be_nil
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
client_params functionality was moved higher up in the client so this is no longer necessary.

Re-added tests