### PR TITLE
Fix oauth2 dependency to 1.4.7

### DIFF
--- a/aptible-auth.gemspec
+++ b/aptible-auth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aptible-resource', '~> 1.0'
   spec.add_dependency 'gem_config'
-  spec.add_dependency 'oauth2', '~> 1.4'
+  spec.add_dependency 'oauth2', '1.4.7'
 
   spec.add_development_dependency 'aptible-tasks', '>= 0.6.0'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Currently, oauth2 1.4.8 includes a change that causes aptible-cli to break when attempting authorization: https://github.com/oauth-xx/oauth2/issues/572

The underlying cause is a hash not being converted to a string, which Faraday's default adapter provides. This will need to be fixed in the oauth2 gem to properly address the issue.

oauth2's current recommendation is to specify the faraday version at the implementation level rather than pin to 1.4.7, but as neither aptible-cli nor aptible-auth-ruby require faraday directly I felt this was the most appropriate short-term fix.