### PR TITLE
Fix oauth2 v2 compatability

### DIFF
--- a/lib/aptible/auth/token.rb
+++ b/lib/aptible/auth/token.rb
@@ -1,5 +1,4 @@
 require 'oauth2'
-require 'oauth2/response_parser'
 require 'oauth2/strategy/token_exchange'
 
 module Aptible
@@ -78,6 +77,7 @@ module Aptible
         options = {
           site: root_url,
           token_url: '/tokens',
+          auth_scheme: :request_body,
           connection_opts: {
             headers: {
               'User-Agent' => Aptible::Resource.configuration.user_agent

--- a/lib/aptible/auth/version.rb
+++ b/lib/aptible/auth/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Auth
-    VERSION = '1.2.6'.freeze
+    VERSION = '1.2.7'.freeze
   end
 end

--- a/lib/oauth2/response_parser.rb
+++ b/lib/oauth2/response_parser.rb
@@ -1,5 +1,0 @@
-# rubocop:disable all
-# NOTE: This code has been in oauth2 master since 2018 but is awaiting a 2.0 release of oauth2
-OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json']) do |body|
-  MultiJson.load(body) rescue body # rubocop:disable RescueModifier
-end


### PR DESCRIPTION
Oauth2 startving from version 2.0 changed https://gitlab.com/ruby-oauth/oauth2/-/blob/main/CHANGELOG.md#changed-6 the auth_scheme default. We were relying on the old scheme of request_body, so we need to just specify it directly.

Also the "copy/pasted" code is not longer up to date with what is in version 2, so removed it for compatability.